### PR TITLE
Use LookupEnv instead of checking for emptyness

### DIFF
--- a/agent/cmd/tinypot/main.go
+++ b/agent/cmd/tinypot/main.go
@@ -56,14 +56,14 @@ var (
 )
 
 func StrFromEnv(envVar string, defaultVal string) string {
-	if value := os.Getenv(envVar); value != "" {
+	if value, ok := os.LookupEnv(envVar); ok {
 		return value
 	}
 	return defaultVal
 }
 
 func BoolFromEnv(envVar string, defaultVal bool) bool {
-	if value := os.Getenv(envVar); value != "" {
+	if value, ok := os.LookupEnv(envVar); ok {
 		boolVal, err := strconv.ParseBool(value)
 		if err != nil {
 			panic(fmt.Sprintf("environment variable `%s` has invalid value `%s`", envVar, value))


### PR DESCRIPTION
If the environment variable is intentionally set to an empty string, the default value will be used instead of the empty string.

>Feel free to close if that was the intended behavior